### PR TITLE
Entferne Drag-Overlay bei Bildern auf Desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ app/config.codekit3
 app/instagram.json
 app/blacklist.json
 app/cache/
+
+# IntelliJ
+.idea

--- a/app/api.php
+++ b/app/api.php
@@ -37,7 +37,7 @@ if (count($allPosts) > 0) {
 				<li data-post-id="<?php echo $post['id']; ?>"
 					data-post-img="<?php echo $post['img']; ?>"
 					data-post-content="<?php echo strip_tags($post['text']); ?>" class="pane<?php echo $i + 1; ?>">
-					<img src="<?php echo $post['img']; ?>" width="300" alt="">
+					<img src="<?php echo $post['img']; ?>" width="300" alt="" draggable="false">
 					<p class="f6 hyphens-auto ma0">
 						<?php
 							$post = $post['text'];

--- a/app/index.php
+++ b/app/index.php
@@ -31,7 +31,7 @@
 		      	<div class="page page-info shadow-1">
 					<div class="pa3">
 						<h3 class="f4 b">Wie funktioniert es?</h3>
-						<img src="img/swipe.gif" alt="Swipe Anleitung">
+						<img src="img/swipe.gif" alt="Swipe Anleitung" draggable="false">
 						<details>
 							<summary class="f4 b" style="margin-top: 10px">Worum geht's?</summary>
 							<p>


### PR DESCRIPTION
Beim Wischen der Tiles auf Desktop gab es einen unschönen Drag-Effekt (siehe Bild)

![drag_overlay](https://user-images.githubusercontent.com/12813885/64982497-9e232500-d8be-11e9-871f-b5089195dc06.png)